### PR TITLE
Update Installation Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Next use `make` to install the extension into your home directory. A Shell reloa
 
 ```bash
 git clone https://github.com/micheleg/dash-to-dock.git
+cd dash-to-dock
 make
 make install
 ```


### PR DESCRIPTION
I tried copying the installation command by using the button in code section. since it was missing the `cd dash-to-dock` command, hence it throw an error.