### PR TITLE
Add support for GNOME 41 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Basic Makefile
 
-UUID = dash-to-dock@micxgx.gmail.com
+UUID = floating-dock@nandoferreira_prof@hotmail.com
 BASE_MODULES = extension.js metadata.json COPYING README.md
 EXTRA_MODULES = dash.js docking.js appIcons.js appIconIndicators.js fileManager1API.js launcherAPI.js locations.js windowPreview.js intellihide.js prefs.js theming.js utils.js dbusmenuUtils.js Settings.ui
 EXTRA_MEDIA = logo.svg glossy.svg highlight_stacked_bg.svg highlight_stacked_bg_h.svg
@@ -14,7 +14,7 @@ else
 	SHARE_PREFIX = $(DESTDIR)/usr/share
 	INSTALLBASE = $(SHARE_PREFIX)/gnome-shell/extensions
 endif
-INSTALLNAME = dash-to-dock@micxgx.gmail.com
+INSTALLNAME = floating-dock@nandoferreira_prof@hotmail.com
 
 # The command line passed variable VERSION is used to set the version string
 # in the metadata and in the generated zip-file. If no VERSION is passed, the
@@ -48,7 +48,7 @@ mergepo: potfile
 
 ./po/dashtodock.pot: $(TOLOCALIZE) Settings.ui
 	mkdir -p po
-	xgettext -k --keyword=__ --keyword=N__ --add-comments='Translators:' -o po/dashtodock.pot --package-name "Dash to Dock" --from-code=utf-8 $(TOLOCALIZE)
+	xgettext -k --keyword=__ --keyword=N__ --add-comments='Translators:' -o po/dashtodock.pot --package-name "Floating Dock" --from-code=utf-8 $(TOLOCALIZE)
 	intltool-extract --type=gettext/glade Settings.ui
 	xgettext -k --keyword=_ --keyword=N_ --join-existing -o po/dashtodock.pot Settings.ui.h
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ now you can edit the margin and border-radius from the dock
 
 ### Build Dependencies
 
-To compile the stylesheet you'll need an implementation of SASS. Dash to Dock supports `dart-sass` (`sass`), `sassc`, and `ruby-sass`. Every distro should have at least one of these implementations, we recommend using `dart-sass` (`sass`) or `sassc` over `ruby-sass` as `ruby-sass` is deprecated.
+To compile the stylesheet you'll need an implementation of SASS. Floating Dock supports `dart-sass` (`sass`), `sassc`, and `ruby-sass`. Every distro should have at least one of these implementations, we recommend using `dart-sass` (`sass`) or `sassc` over `ruby-sass` as `ruby-sass` is deprecated.
 
-By default, Dash to Dock will attempt to build with `dart-sass`. To change this behavior set the `SASS` environment variable to either `sassc` or `ruby`.
+By default, Floating Dock will attempt to build with `dart-sass`. To change this behavior set the `SASS` environment variable to either `sassc` or `ruby`.
 
 ```bash
 export SASS=sassc
@@ -46,5 +46,5 @@ make install
 Bugs should be reported to the Github bug tracker [https://github.com/micheleg/dash-to-dock/issues](https://github.com/micheleg/dash-to-dock/issues).
 
 ## License
-Dash to Dock Gnome Shell extension is distributed under the terms of the GNU General Public License,
+Floating Dock Gnome Shell extension is distributed under the terms of the GNU General Public License,
 version 2 or later. See the COPYING file for details.

--- a/Settings.ui
+++ b/Settings.ui
@@ -2132,7 +2132,7 @@
             <child>
               <object class="GtkLabel" id="extension_name">
                 <property name="can_focus">0</property>
-                <property name="label">&lt;b&gt;Dash to Dock&lt;/b&gt;</property>
+                <property name="label">&lt;b&gt;Floating Dock&lt;/b&gt;</property>
                 <property name="use_markup">1</property>
               </object>
             </child>

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -11,6 +11,7 @@ $dash_background_color: #3b3b3b;
 $dash_placeholder_size: 32px;
 $dash_padding: $base_padding + 4px; // 10px
 $dash_spacing: round($base_padding / 4);
+$dash_edge_items_padding: $dash_padding - $dash_spacing;
 $dash_bottom_margin: $base_margin * 4;
 $dash_border_radius: $modal_radius * 1.5;
 
@@ -22,6 +23,10 @@ $dock_fixed_inner_margin: $dock_side_margin;
 
 @function shrink($val) {
     @return round($val / 4);
+}
+
+@function is_horizontal($side) {
+    @return $side == top or $side == bottom;
 }
 
 @function opposite($val) {
@@ -51,7 +56,7 @@ $osd_fg_color: #eeeeec;
             }
 
             .dash-separator {
-                @if $side == top or $side == bottom {
+                @if is_horizontal($side) {
                     margin-bottom: 0;
                 } @else {
                     height: 1px;
@@ -133,27 +138,69 @@ $osd_fg_color: #eeeeec;
     }
 }
 
+@mixin padded-edge-child($chid, $side, $padding) {
+    @if $chid == first {
+        @if is_horizontal($side) {
+            padding-left: $padding;
+        } @else {
+            padding-top: $padding;
+        }
+    } @else if $chid == last {
+        @if is_horizontal($side) {
+            padding-right: $padding;
+        } @else {
+            padding-bottom: $padding;
+        }
+    } @else {
+        @error "Invalid rule";
+    }
+}
+
+/* In extended mode we need to use the first and last .dash-item-container's
+ * to apply the padding on the dock, to ensure that the actual first or last
+ * child show-apps item will actually include the padding area so that it will
+ * be clickable up to the dock edge, and make Fitts happy.
+ * I don't think the same should happen for normal icons, so in the other side
+ * the padding will be applied via the scrolled area, given we can't get the
+ * parent of the first/last app-well-app icon to apply a rule there.
+ */
+@mixin padded-dash-edge-items($side, $padding) {
+    @each $child_pos in first, last {
+        > :#{$child_pos}-child {
+            /* Use this instead of #dashtodockDashScrollview rule to apply the
+             * padding via the last app-icon item */
+            // .dash-item-container:#{$child_pos}-child .app-well-app,
+            .show-apps {
+                @include padded-edge-child($child_pos, $side, $padding);
+            }
+        }
+
+        #dashtodockDashScrollview:#{$child_pos}-child {
+            @include padded-edge-child($child_pos, $side, $padding);
+        }
+    }
+}
+
 @each $side in bottom, top, left, right {
     #dashtodockContainer.extended.#{$side} {
         #dash {
             .dash-background {
                 margin: 0;
-                padding: 0;
                 border-radius: 0;
             }
 
             #dashtodockDashContainer {
-                padding: $dash_padding - $dash_spacing;
+                padding: 0;
                 padding-#{$side}: 0;
                 padding-#{opposite($side)}: 0;
+
+                @include padded-dash-edge-items($side, $dash_edge_items_padding);
             }
 
             .dash-item-container {
                 .app-well-app,
                 .show-apps {
-                    padding: $dash_spacing;
                     padding-#{$side}: $dash_padding;
-                    padding-#{opposite($side)}: $dash_padding;
                 }
             }
         }
@@ -161,17 +208,15 @@ $osd_fg_color: #eeeeec;
         &.shrink {
             #dash {
                 #dashtodockDashContainer {
-                    padding: shrink($dash_padding - $dash_spacing);
-                    padding-#{$side}: 0;
-                    padding-#{opposite($side)}: 0;
+                    padding: 0;
+
+                    @include padded-dash-edge-items($side, shrink($dash_edge_items_padding));
                 }
 
                 .dash-item-container {
                     .app-well-app,
                     .show-apps {
-                        padding: shrink($dash_spacing);
                         padding-#{$side}: shrink($dash_padding);
-                        padding-#{opposite($side)}: shrink($dash_padding);
                     }
                 }
             }
@@ -294,36 +339,18 @@ $osd_fg_color: #eeeeec;
     border-radius: 0px;
 }
 
-#dashtodockContainer.bottom .metro.running2.focused,
-#dashtodockContainer.bottom .metro.running3.focused,
-#dashtodockContainer.bottom .metro.running4.focused,
-#dashtodockContainer.top .metro.running2.focused,
-#dashtodockContainer.top .metro.running3.focused,
-#dashtodockContainer.top .metro.running4.focused {
-    background-image: url("./media/highlight_stacked_bg.svg");
-    background-position: 0px 0px;
-    background-size: contain;
-}
+@for $i from 2 through 4 {
+    #dashtodockContainer.bottom .metro.running#{$i}.focused,
+    #dashtodockContainer.top .metro.running#{$i}.focused {
+        background-image: url("./media/highlight_stacked_bg.svg");
+        background-position: 0px 0px;
+        background-size: contain;
+    }
 
-#dashtodockContainer.left .metro.running2.focused,
-#dashtodockContainer.left .metro.running3.focused,
-#dashtodockContainer.left .metro.running4.focused,
-#dashtodockContainer.right .metro.running2.focused,
-#dashtodockContainer.right .metro.running3.focused,
-#dashtodockContainer.right .metro.running4.focused {
-    background-image: url("./media/highlight_stacked_bg_h.svg");
-    background-position: 0px 0px;
-    background-size: contain;
-}
-
-.app-well-app {
-    border-radius: 100px; 
-  }
-  
-.app-well-app * {
-    border-radius: 100px; 
-}
-  
-.show-apps * {
-    border-radius: 100px;
+    #dashtodockContainer.left .metro.running#{$i}.focused,
+    #dashtodockContainer.right .metro.running#{$i}.focused {
+        background-image: url("./media/highlight_stacked_bg_h.svg");
+        background-position: 0px 0px;
+        background-size: contain;
+    }
 }

--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -149,6 +149,10 @@ var RunningIndicatorBase = class DashToDock_RunningIndicatorBase extends Indicat
         this.update();
     }
 
+    get _number() {
+        return Math.min(this._source.windowsCount, MAX_WINDOWS_CLASSES);
+    }
+
     update() {
         this._updateCounterClass();
         this._updateDefaultDot();
@@ -157,7 +161,7 @@ var RunningIndicatorBase = class DashToDock_RunningIndicatorBase extends Indicat
     _updateCounterClass() {
         for (let i = 1; i <= MAX_WINDOWS_CLASSES; i++) {
             let className = 'running' + i;
-            if (i != this._source.windowsCount)
+            if (i != this._number)
                 this._source.remove_style_class_name(className);
             else
                 this._source.add_style_class_name(className);
@@ -389,7 +393,7 @@ var RunningIndicatorDots = class DashToDock_RunningIndicatorDots extends Running
 
     _drawIndicator(cr) {
         // Draw the required numbers of dots
-        let n = this._source.windowsCount;
+        let n = this._number;
 
         cr.setLineWidth(this._borderWidth);
         Clutter.cairo_set_source_color(cr, this._borderColor);
@@ -420,7 +424,7 @@ var RunningIndicatorCiliora = class DashToDock_RunningIndicatorCiliora extends R
         if (this._source.running) {
             let size =  Math.max(this._width/20, this._borderWidth);
             let spacing = size; // separation between the dots
-            let lineLength = this._width - (size*(this._source.windowsCount-1)) - (spacing*(this._source.windowsCount-1));
+            let lineLength = this._width - (size*(this._number-1)) - (spacing*(this._number-1));
             let padding = this._borderWidth;
             // For the backlit case here we don't want the outer border visible
             if (Docking.DockManager.settings.get_boolean('unity-backlit-items') &&
@@ -434,7 +438,7 @@ var RunningIndicatorCiliora = class DashToDock_RunningIndicatorCiliora extends R
             cr.translate(0, yOffset);
             cr.newSubPath();
             cr.rectangle(0, 0, lineLength, size);
-            for (let i = 1; i < this._source.windowsCount; i++) {
+            for (let i = 1; i < this._number; i++) {
                 cr.newSubPath();
                 cr.rectangle(lineLength + (i*spacing) + ((i-1)*size), 0, size, size);
             }
@@ -454,8 +458,8 @@ var RunningIndicatorSegmented = class DashToDock_RunningIndicatorSegmented exten
         if (this._source.running) {
             let size =  Math.max(this._width/20, this._borderWidth);
             let spacing = Math.ceil(this._width/18); // separation between the dots
-            let dashLength = Math.ceil((this._width - ((this._source.windowsCount-1)*spacing))/this._source.windowsCount);
-            let lineLength = this._width - (size*(this._source.windowsCount-1)) - (spacing*(this._source.windowsCount-1));
+            let dashLength = Math.ceil((this._width - ((this._number-1)*spacing))/this._number);
+            let lineLength = this._width - (size*(this._number-1)) - (spacing*(this._number-1));
             let padding = this._borderWidth;
             // For the backlit case here we don't want the outer border visible
             if (Docking.DockManager.settings.get_boolean('unity-backlit-items') &&
@@ -467,7 +471,7 @@ var RunningIndicatorSegmented = class DashToDock_RunningIndicatorSegmented exten
             Clutter.cairo_set_source_color(cr, this._borderColor);
 
             cr.translate(0, yOffset);
-            for (let i = 0; i < this._source.windowsCount; i++) {
+            for (let i = 0; i < this._number; i++) {
                 cr.newSubPath();
                 cr.rectangle(i*dashLength + i*spacing, 0, dashLength, size);
             }
@@ -521,8 +525,8 @@ var RunningIndicatorSquares = class DashToDock_RunningIndicatorSquares extends R
             cr.setLineWidth(this._borderWidth);
             Clutter.cairo_set_source_color(cr, this._borderColor);
 
-            cr.translate(Math.floor((this._width - this._source.windowsCount*size - (this._source.windowsCount-1)*spacing)/2), yOffset);
-            for (let i = 0; i < this._source.windowsCount; i++) {
+            cr.translate(Math.floor((this._width - this._number*size - (this._number-1)*spacing)/2), yOffset);
+            for (let i = 0; i < this._number; i++) {
                 cr.newSubPath();
                 cr.rectangle(i*size + i*spacing, 0, size, size);
             }
@@ -548,8 +552,8 @@ var RunningIndicatorDashes = class DashToDock_RunningIndicatorDashes extends Run
             cr.setLineWidth(this._borderWidth);
             Clutter.cairo_set_source_color(cr, this._borderColor);
 
-            cr.translate(Math.floor((this._width - this._source.windowsCount*dashLength - (this._source.windowsCount-1)*spacing)/2), yOffset);
-            for (let i = 0; i < this._source.windowsCount; i++) {
+            cr.translate(Math.floor((this._width - this._number*dashLength - (this._number-1)*spacing)/2), yOffset);
+            for (let i = 0; i < this._number; i++) {
                 cr.newSubPath();
                 cr.rectangle(i*dashLength + i*spacing, 0, dashLength, size);
             }
@@ -585,7 +589,7 @@ var RunningIndicatorMetro = class DashToDock_RunningIndicatorMetro extends Runni
                 padding = 0;
             let yOffset = this._height - padding - size;
 
-            let n = this._source.windowsCount;
+            let n = this._number;
             if(n <= 1) {
                 cr.translate(0, yOffset);
                 Clutter.cairo_set_source_color(cr, this._bodyColor);

--- a/appIcons.js
+++ b/appIcons.js
@@ -1370,7 +1370,7 @@ class DockShowAppsIconMenu extends DockAppIconMenu {
 
         /* Translators: %s is "Settings", which is automatically translated. You
            can also translate the full message if this fits better your language. */
-        let name = __('Dash to Dock %s').format(_('Settings'))
+        let name = __('Floating Dock %s').format(_('Settings'))
         let item = this._appendMenuItem(name);
 
         item.connect('activate', function () {

--- a/dash.js
+++ b/dash.js
@@ -124,7 +124,6 @@ var DockDash = GObject.registerClass({
             vertical: !this._isHorizontal,
             y_expand: this._isHorizontal,
             x_expand: !this._isHorizontal,
-            pack_start: Docking.DockManager.settings.get_boolean('show-apps-at-top')
         });
 
         this._scrollView = new St.ScrollView({
@@ -172,7 +171,11 @@ var DockDash = GObject.registerClass({
             this._itemMenuStateChanged(this._showAppsIcon, opened);
         });
 
-        this._dashContainer.add_child(this._showAppsIcon);
+        if (Docking.DockManager.settings.get_boolean('show-apps-at-top')) {
+            this._dashContainer.insert_child_below(this._showAppsIcon, null);
+        } else {
+            this._dashContainer.insert_child_above(this._showAppsIcon, null);
+        }
 
         this._background = new St.Widget({
             style_class: 'dash-background',
@@ -1002,20 +1005,12 @@ var DockDash = GObject.registerClass({
     }
 
     showShowAppsButton() {
-        this.showAppsButton.visible = true
-        this.showAppsButton.set_width(-1)
-        this.showAppsButton.set_height(-1)
+        this._showAppsIcon.visible = true;
+        this._showAppsIcon.show(true);
     }
 
     hideShowAppsButton() {
-        //this.showAppsButton.hide()
-
-        // The height and width of the button is bound to the background.
-        if (this._isHorizontal) {
-            this.showAppsButton.set_width(0)
-        } else {
-            this.showAppsButton.set_height(0)
-        }
+        this._showAppsIcon.visible = false;
     }
 
     setMaxSize(maxWidth, maxHeight) {
@@ -1029,11 +1024,27 @@ var DockDash = GObject.registerClass({
     }
 
     updateShowAppsButton() {
+        const notifiedProperties = [];
+        this._signalsHandler.addWithLabel('first-last-child-workaround',
+            this._dashContainer, 'notify',
+            (_obj, pspec) => notifiedProperties.push(pspec.name));
+
         if (Docking.DockManager.settings.get_boolean('show-apps-at-top')) {
-            this._dashContainer.pack_start = true;
+            this._dashContainer.set_child_below_sibling(this._showAppsIcon, null);
         } else {
-            this._dashContainer.pack_start = false;
+            this._dashContainer.set_child_above_sibling(this._showAppsIcon, null);
         }
+
+        this._signalsHandler.removeWithLabel('first-last-child-workaround');
+
+        // This is indeed ugly, but we need to ensure that the last and first
+        // visible widgets are re-computed by St, that is buggy because of a
+        // mutter issue that is being fixed:
+        // https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2047
+        if (!notifiedProperties.includes('first-child'))
+            this._dashContainer.notify('first-child');
+        if (!notifiedProperties.includes('last-child'))
+            this._dashContainer.notify('last-child');
     }
 });
 

--- a/docking.js
+++ b/docking.js
@@ -10,6 +10,7 @@ const St = imports.gi.St;
 const Params = imports.misc.params;
 
 const Main = imports.ui.main;
+const AppDisplay = imports.ui.appDisplay;
 const Dash = imports.ui.dash;
 const IconGrid = imports.ui.iconGrid;
 const Overview = imports.ui.overview;
@@ -2104,6 +2105,15 @@ var DockManager = class DashToDock_DockManager {
                         box.set_origin(box.x1 + preferredWidth, box.y1);
                 }
                 return box;
+            });
+
+        // Ensure we handle Dnd events happening on the dock when we're dragging from AppDisplay
+        // Remove when merged https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2002
+        this._methodInjections.addWithLabel('main-dash', AppDisplay.BaseAppView.prototype,
+            '_pageForCoords', function (originalFunction, ...args) {
+                if (!this._scrollView.has_pointer)
+                    return AppDisplay.SidePages.NONE;
+                return originalFunction.call(this, ...args);
             });
     }
 

--- a/locations.js
+++ b/locations.js
@@ -589,7 +589,7 @@ var Removables = class DashToDock_Removables {
             return;
         }
 
-        let escapedUri = mount.get_root().get_uri()
+        const escapedUri = mount.get_default_location().get_uri()
         let uri = GLib.uri_unescape_string(escapedUri, null);
 
         let mountKeys = new GLib.KeyFile();

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
 ],
 "uuid": "floating-dock@nandoferreira_prof@hotmail.com",
 "name": "Floating Dock",
-"description": "A Custom dash to dock fork, now you can change the margin and border radius of the dock.",
+"description": "A Custom Floating Dock fork, now you can change the margin and border radius of the dock.",
 "original-author": "micxgx@gmail.com",
 "url": "https://github.com/fer-moreira/floating-dock",
 "gettext-domain": "floatingdock",

--- a/metadata.json
+++ b/metadata.json
@@ -9,5 +9,5 @@
 "original-author": "micxgx@gmail.com",
 "url": "https://github.com/fer-moreira/floating-dock",
 "gettext-domain": "floatingdock",
-"version": 2
+"version": 3
 }

--- a/po/ar.po
+++ b/po/ar.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-06-04 12:35+0100\n"
 "PO-Revision-Date: 2015-04-18 18:01+0100\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-16 13:48+0200\n"
 "PO-Revision-Date: 2020-05-16 13:54+0200\n"
@@ -71,8 +71,8 @@ msgstr "Ukončit %d oken"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1134
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "%s Dash to Docku"
+msgid "Floating Dock %s"
+msgstr "%s Floating Docku"
 
 #: locations.js:65
 msgid "Trash"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-06-04 12:35+0100\n"
 "PO-Revision-Date: 2017-12-11 19:21+0100\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-06-04 12:35+0100\n"
 "PO-Revision-Date: 2017-09-29 21:48+0300\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1,5 +1,5 @@
-# Dash to Dock spanish translation.
-# This file is distributed under the same license as the Dash to Dock package.
+# Floating Dock spanish translation.
+# This file is distributed under the same license as the Floating Dock package.
 # Hugo Olabera <hugolabe@gmail.com>, 2015.
 #
 msgid ""
@@ -61,8 +61,8 @@ msgstr "Todas las ventanas"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1092
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "%s • Dash to Dock"
+msgid "Floating Dock %s"
+msgstr "%s • Floating Dock"
 
 #: Settings.ui.h:1
 msgid ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -1,5 +1,5 @@
-# Dash to Dock Basque translation.
-# This file is distributed under the same license as the Dash to Dock package.
+# Floating Dock Basque translation.
+# This file is distributed under the same license as the Floating Dock package.
 # Ibai Oihanguren Sala <ibai@oihanguren.com>, 2020.
 #
 msgid ""
@@ -63,8 +63,8 @@ msgstr "Leiho guztiak"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1119
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock %s"
+msgid "Floating Dock %s"
+msgstr "Floating Dock %s"
 
 #: locations.js:65
 msgid "Trash"

--- a/po/fr.po
+++ b/po/fr.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-07 16:40+0900\n"
 "PO-Revision-Date: 2019-12-07 16:52+0900\n"
@@ -65,8 +65,8 @@ msgstr "Toutes les fenêtres"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1127
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock %s"
+msgid "Floating Dock %s"
+msgstr "Floating Dock %s"
 
 #: Settings.ui.h:1
 msgid ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -1,5 +1,5 @@
-# Dash to Dock galician translation.
-# This file is distributed under the same license as the Dash to Dock package.
+# Floating Dock galician translation.
+# This file is distributed under the same license as the Floating Dock package.
 # Xosé M. Lamas <correo@xmgz.eu>, 2018.
 #
 msgid ""

--- a/po/it.po
+++ b/po/it.po
@@ -65,8 +65,8 @@ msgstr "Tutte le finestre"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1091
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "%s di «Dash to Dock»"
+msgid "Floating Dock %s"
+msgstr "%s di «Floating Dock»"
 
 #: Settings.ui.h:1
 msgid ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,4 +1,4 @@
-# Dash to Dock master ja.po
+# Floating Dock master ja.po
 # Copyright (C) 2013-2017, 2019-2020 THE dash-to-dock'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the dash-to-dock package.
 # Jiro Matsuzawa <jmatsuzawa@gnome.org>, 2013.
@@ -59,8 +59,8 @@ msgstr "%d 個のウィンドウを終了"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1134
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock の%s"
+msgid "Floating Dock %s"
+msgstr "Floating Dock の%s"
 
 #: appIcons.js:1134
 msgid "Settings"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,4 +1,4 @@
-# Norwegian Bokmål translation for Dash to Dock.
+# Norwegian Bokmål translation for Floating Dock.
 # Copyright (C) 2018 Michele
 # This file is distributed under the same license as the dash-to-dock package.
 # Harald H. <harald@fsfe.org>, 2018.
@@ -67,8 +67,8 @@ msgstr "Alle vinduer"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1069
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock %s"
+msgid "Floating Dock %s"
+msgstr "Floating Dock %s"
 
 #: Settings.ui.h:1
 msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@
 # Heimen Stoffels <vistausss@outlook.com>, 2015, 2019.
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-10-10 20:27+0200\n"
 "PO-Revision-Date: 2019-10-10 20:46+0200\n"
@@ -70,8 +70,8 @@ msgstr "Alle vensters"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1126
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock %s"
+msgid "Floating Dock %s"
+msgstr "Floating Dock %s"
 
 #: Settings.ui.h:1
 msgid ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -70,8 +70,8 @@ msgstr "Wszystkie okna"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1126
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "%s Dash to Dock"
+msgid "Floating Dock %s"
+msgstr "%s Floating Dock"
 
 #: locations.js:65
 msgid "Trash"

--- a/po/pt.po
+++ b/po/pt.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-06 01:57-0600\n"
 "PO-Revision-Date: 2019-03-06 03:55-0600\n"
@@ -66,8 +66,8 @@ msgstr "Todas as janelas"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1092
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "%s do Dash to Dock"
+msgid "Floating Dock %s"
+msgstr "%s do Floating Dock"
 
 #: Settings.ui.h:1
 msgid ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-06 01:57-0600\n"
 "PO-Revision-Date: 2019-03-06 03:56-0600\n"
@@ -67,8 +67,8 @@ msgstr "Todas as janelas"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1092
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "%s do Dash to Dock"
+msgid "Floating Dock %s"
+msgstr "%s do Floating Dock"
 
 #: Settings.ui.h:1
 msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -65,7 +65,7 @@ msgstr "Все окна"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1127
 #, javascript-format
-msgid "Dash to Dock %s"
+msgid "Floating Dock %s"
 msgstr ""
 
 #: Settings.ui.h:1

--- a/po/sr.po
+++ b/po/sr.po
@@ -63,7 +63,7 @@ msgstr "Сви прозори"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1450
 #, javascript-format
-msgid "Dash to Dock %s"
+msgid "Floating Dock %s"
 msgstr "%s плоче/панела"
 
 #: Settings.ui.h:1

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -63,7 +63,7 @@ msgstr "Svi prozori"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1450
 #, javascript-format
-msgid "Dash to Dock %s"
+msgid "Floating Dock %s"
 msgstr "%s ploče/panela"
 
 #: Settings.ui.h:1

--- a/po/sv.po
+++ b/po/sv.po
@@ -71,8 +71,8 @@ msgstr "Stäng %d fönster"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1134
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "%s för Dash to Dock"
+msgid "Floating Dock %s"
+msgstr "%s för Floating Dock"
 
 #: locations.js:80
 msgid "Trash"

--- a/po/tr.po
+++ b/po/tr.po
@@ -74,8 +74,8 @@ msgstr "Tüm Pencereler"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1126
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock %sı"
+msgid "Floating Dock %s"
+msgstr "Floating Dock %sı"
 
 #: Settings.ui.h:1
 msgid "When set to minimize, double clicking minimizes all the windows of the application."

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -60,7 +60,7 @@ msgstr "Усі вікна"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1429
 #, javascript-format
-msgid "Dash to Dock %s"
+msgid "Floating Dock %s"
 msgstr ""
 
 #: Settings.ui.h:1

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-03-23 15:33+0800\n"
 "PO-Revision-Date: 2017-08-03 22:49+0800\n"
@@ -68,8 +68,8 @@ msgstr "所有窗口"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1125
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock %s"
+msgid "Floating Dock %s"
+msgstr "Floating Dock %s"
 
 #: locations.js:65
 msgid "Trash"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Dash to Dock\n"
+"Project-Id-Version: Floating Dock\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-23 23:49+0800\n"
 "PO-Revision-Date: 2020-05-24 00:08+0800\n"
@@ -71,8 +71,8 @@ msgstr "結束 %d 個視窗"
 #. can also translate the full message if this fits better your language.
 #: appIcons.js:1134
 #, javascript-format
-msgid "Dash to Dock %s"
-msgstr "Dash to Dock %s"
+msgid "Floating Dock %s"
+msgstr "Floating Dock %s"
 
 #: locations.js:65
 msgid "Trash"

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -26,8 +26,7 @@ const PREVIEW_ANIMATION_DURATION = 250;
 var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.PopupMenu {
 
     constructor(source) {
-        let side = Utils.getPosition();
-        super(source, 0.5, side);
+        super(source, 0.5, Utils.getPosition());
 
         // We want to keep the item hovered while the menu is up
         this.blockSourceEvents = true;
@@ -37,6 +36,7 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
         let monitorIndex = this._source.monitorIndex;
 
         this.actor.add_style_class_name('app-well-menu');
+        this.actor.add_style_class_name('app-menu');
         this.actor.set_style('max-width: '  + (Main.layoutManager.monitors[monitorIndex].width  - 22) + 'px; ' +
                              'max-height: ' + (Main.layoutManager.monitors[monitorIndex].height - 22) + 'px;');
         this.actor.hide();
@@ -49,11 +49,6 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
         this._destroyId = this._source.connect('destroy', this.destroy.bind(this));
 
         Main.uiGroup.add_actor(this.actor);
-
-        // Change the initialized side where required.
-        this._arrowSide = side;
-        this._boxPointer._arrowSide = side;
-        this._boxPointer._userArrowSide = side;
 
         this.connect('destroy', this._onDestroy.bind(this));
     }


### PR DESCRIPTION
## Changelog:

- location: Use default location as mount URI
- appIconIndicators: Limit the number of running indicators to 4
- appIcons: Ensure we update the icon geometry on icon creation
- docking: Fix DnD from AppView to dock on the left
- theming: Use rgba color when using fixed opacity with custom color
- dash: Remove commented code
- dash: Don't change packing just to reorder dash children (and show Apps)
- dash: Also unset the opacity from the show-apps button when hidden
- stylesheet: Avoid repeating rules in extended mode that have been def…
- stylesheet: Use some scss features to repeat running states styles
- stylesheet: Control dash padding via the edge dash items
- appIcons: Reimplement DockAppIconMenu to be compatible with 40 and 41

